### PR TITLE
extract docker repo creation to gcp-env-terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,22 +98,13 @@ locals {
   docker_registry_project = one(regex("^[^/]+/([^/]+).*$", var.docker_registry))
 }
 
-// Create a docker registry repo
-resource "google_artifact_registry_repository" "docker" {
-  project       = local.docker_registry_project
-  provider      = google-beta
-  location      = "us"
-  repository_id = var.repo
-  description   = "Docker registry for ${var.repo}'s images"
-  format        = "DOCKER"
-}
 // Allow stack's terraformer to manage all docker repo artifacts and versions
 // Terraform planner already has read permissions by its group membership status
 resource "google_artifact_registry_repository_iam_member" "member" {
-  project    = local.docker_registry_project
   provider   = google-beta
-  location   = google_artifact_registry_repository.docker.location
-  repository = google_artifact_registry_repository.docker.name
+  project    = local.docker_registry_project
+  location   = "us"
+  repository = "projects/${local.docker_registry_project}/locations/us/repositories/${var.repo}"
   role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${google_service_account.terraformer.email}"
 }


### PR DESCRIPTION
when this module was attempting to create the docker repos, it was
failing because each environment was trying to create it when it already
existed

bump #patch
