### PR TITLE
version 10

### DIFF
--- a/.github/workflows/publish-terraform-module.yml
+++ b/.github/workflows/publish-terraform-module.yml
@@ -1,75 +1,21 @@
-name: Publish Terraform module
+# When a commit is made to main, perform a GitHub release, bumping the semantic
+# version. Defaults to `default-bump` param, override with
+# `#major`/`#minor`/`#patch` in the commit message
+name: Publish Terraform Module
 
 on:
   push:
     branches:
-      - "*"
+      - "main"
 
 jobs:
-  validate:
-    name: Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Set up Terraform cli
-        uses: hashicorp/setup-terraform@v1
-      - name: Terraform fmt
-        run: |
-          set +e
-          terraform fmt -check
-          if [[ $? -ne 0 ]]; then
-            echo "Be sure to run 'terraform fmt' before committing. This can usually be done in your IDE of choice"
-            exit 1
-          fi
-          set -e
-      - name: TF init
-        run: terraform init -input=false -backend=false
-      - name: TF validate
-        run: terraform validate
-
   release:
-    name: Release
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - validate
+    name: GitHub Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: GitHub Tag Bump
-        uses: anothrNick/github-tag-action@1.36.0
-        id: tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BUMP: minor
-          WITH_V: true
-          DRY_RUN: true
-      - name: List Release
-        run: echo "This will create the release '${{ steps.tag.outputs.new_tag }}'"
-      - name: Create Release
-        uses: ncipollo/release-action@v1
+      - name: GitHub semver release
+        uses: vivantehealth/github-semver-release-action@v0
         with:
-          body: ${{ github.event.head_commit.message }}
-          tag: ${{ steps.tag.outputs.new_tag }}
-      - name: Parse higher semantic versions
-        id: semver
-        run: |
-          TAG="${{ steps.tag.outputs.new_tag }}"
-          MINOR="${TAG%.*}"
-          MAJOR="${MINOR%.*}"
-          echo "::set-output name=major::$(echo $MAJOR)"
-          echo "::set-output name=minor::$(echo $MINOR)"
-      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
-        with:
-          tag_name: ${{ steps.semver.outputs.major }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update major version
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          omitBodyDuringUpdate: true
-          omitNameDuringUpdate: true
-          body: ${{ github.event.head_commit.message }}
-          tag: ${{ steps.semver.outputs.major }}
+          default-bump: minor

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Publish Terraform module
+name: Validate Terraform module
 
 on:
   push:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Publish Terraform module
+
+on:
+  push:
+    branches:
+      - "*"
+      - "!main"
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Terraform cli
+        uses: hashicorp/setup-terraform@v1
+      - name: Terraform fmt
+        run: |
+          set +e
+          terraform fmt -check
+          if [[ $? -ne 0 ]]; then
+            echo "Be sure to run 'terraform fmt' before committing. This can usually be done in your IDE of choice"
+            exit 1
+          fi
+          set -e
+      - name: TF init
+        run: terraform init -input=false -backend=false
+      - name: TF validate
+        run: terraform validate

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,11 @@ data "github_team" "owner" {
 resource "github_repository_environment" "repo_ci_environment" {
   repository  = var.repo
   environment = "${var.env_id}-ci"
+  # There appears to be no way to set the branch pattern through the API. See https://github.com/integrations/terraform-provider-github/issues/922#issuecomment-998957627
+  deployment_branch_policy {
+    protected_branches     = var.restrict_environment_branches
+    custom_branch_policies = !var.restrict_environment_branches
+  }
 }
 resource "github_repository_environment" "repo_cd_environment" {
   repository  = var.repo
@@ -19,6 +24,10 @@ resource "github_repository_environment" "repo_cd_environment" {
   reviewers {
     teams = [data.github_team.owner.id]
     users = []
+  }
+  deployment_branch_policy {
+    protected_branches     = var.restrict_environment_branches
+    custom_branch_policies = !var.restrict_environment_branches
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,13 @@ resource "github_actions_environment_secret" "cd_base64_terraform_project_id" {
 }
 
 # Set parameters needed for workload identity. Provider id set at the org level
-resource "github_actions_environment_secret" "iac_gcp_service_account" {
+resource "github_actions_environment_secret" "ci_gcp_service_account" {
+  repository      = var.repo
+  environment     = github_repository_environment.repo_ci_environment.environment
+  secret_name     = "BASE64_GCP_SERVICE_ACCOUNT" #tfsec:ignore:GEN003 this isn't sensitive
+  plaintext_value = base64encode(google_service_account.gha_iac.email)
+}
+resource "github_actions_environment_secret" "cd_gcp_service_account" {
   repository      = var.repo
   environment     = github_repository_environment.repo_cd_environment.environment
   secret_name     = "BASE64_GCP_SERVICE_ACCOUNT" #tfsec:ignore:GEN003 this isn't sensitive

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,38 +2,14 @@ output "repo" {
   value = var.repo
 }
 
-output "repo_ci_sa_email" {
-  value = google_service_account.gha_ci.email
-}
-
-output "repo_ci_sa_id" {
-  value = google_service_account.gha_ci.id
-}
-
-output "repo_ci_environment" {
-  value = github_repository_environment.repo_ci_environment.environment
-}
-
 output "repo_cd_sa_email" {
-  value = google_service_account.gha_cd.email
+  value = google_service_account.gha_iac.email
 }
 
 output "repo_cd_sa_id" {
-  value = google_service_account.gha_cd.id
+  value = google_service_account.gha_iac.id
 }
 
 output "repo_cd_environment" {
   value = github_repository_environment.repo_cd_environment.environment
-}
-
-output "repo_infra_sa_email" {
-  value = google_service_account.gha_infra.email
-}
-
-output "repo_infra_sa_id" {
-  value = google_service_account.gha_infra.id
-}
-
-output "repo_infra_environment" {
-  value = github_repository_environment.repo_infra_environment.environment
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,24 +30,8 @@ variable "registry_readers_google_group_id" {
   default     = ""
 }
 
-variable "infra_reviewers" {
-  description = "GitHub teams required to review the job for infrastructure changes. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access"
-  type        = string
-}
-
-variable "cd_reviewers" {
-  description = "GitHub teams required to review the job for application updates. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access. If not set, will be the same as infra_reviewers"
-  type        = string
-  default     = ""
-}
-
-variable "iac_readers_google_group_id" {
-  description = "Google group ID to place the CI service account in"
-  type        = string
-}
-
-variable "iac_limited_google_group_id" {
-  description = "Google group ID to place the limited CD service account in"
+variable "owner" {
+  description = "GitHub teams required to review the job for application updates. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access. Example: eng"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,11 @@ variable "owner" {
   type        = string
 }
 
+variable "restrict_environment_branches" {
+  description = "Whether to restrict deployment using <env>-ci and <env>-cd environments to protected branches"
+  type        = bool
+}
+
 variable "iac_admins_google_group_id" {
   description = "Google group ID to place the infrastructure-provisioning service account in"
   type        = string


### PR DESCRIPTION
Breaking change. Allows stack "owner" to be specified. This is used, along with the new `restrict_environment_branches` variable, to provide better guarantees about who and what can run when and where. The owner field is used for environments, and determines which github team needs to approve a job that uses the `<env>-cd` environment (e.g. a terraform apply). When `restrict_environment_branches` is set to true, the `<env>-ci` and `<env>-cd` environments can only be run from protected branches, ensuring enforcement of PR review by CODEOWNERS (assuming appropriate repo settings). All of this allows us to move from 3 service accounts per stack to 1, and from 3 repo environments to 2.
