### PR TITLE
folder roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "google_project_iam_member" "iac_owner" {
 // Used for things like the log-archive stack to set folder audit configs
 resource "google_folder_iam_member" "iac_folder_permissions" {
   folder   = var.env_folder_id
-  for_each = var.folder_roles
+  for_each = toset(var.folder_roles)
   role     = each.value
   member   = "serviceAccount:${google_service_account.gha_iac.email}"
 }

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,15 @@ resource "google_project_iam_member" "iac_owner" {
   member  = "serviceAccount:${google_service_account.gha_iac.email}"
 }
 
+// Give the iac accounts permission overrides at the folder level (if specified)
+// Used for things like the log-archive stack to set folder audit configs
+resource "google_folder_iam_member" "iac_folder_permissions" {
+  folder   = var.env_folder_id
+  for_each = var.folder_roles
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.gha_iac.email}"
+}
+
 // Allow gha-iac SA to view or manage membership of the iac admins security group, depending on the value of var.group_roles
 // Usually only the folder terraformer needs to be a manager.
 resource "google_cloud_identity_group_membership" "iac_admins_membership" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "folder_roles" {
 variable "env_folder_id" {
   description = "Environment folder's id. Required when folder_roles is set"
   type        = string
+  default     = ""
 }
 
 variable "domain_project_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,17 @@ variable "env_id" {
   type        = string
 }
 
+variable "folder_roles" {
+  description = "Roles to give the IaC accounts at the folder level"
+  default     = []
+  type        = list(string)
+}
+
+variable "env_folder_id" {
+  description = "Environment folder's id. Required when folder_roles is set"
+  type        = string
+}
+
 variable "domain_project_id" {
   description = "Domain's GCP Project ID"
   type        = string


### PR DESCRIPTION
- support adding folder roles to a stack's iac account

new optional variable `folder_roles`, new conditionally-required variable `env_folder_id` required with `folder_roles` is set