### PR TITLE
GitHub team ids

### DIFF
--- a/environment_secrets.tf
+++ b/environment_secrets.tf
@@ -19,6 +19,21 @@ resource "github_actions_environment_secret" "cd_base64_docker_registry" {
   plaintext_value = base64encode(var.docker_registry) #tfsec:ignore:no-plaintext-exposure this isn't sensitive
 }
 
+resource "github_actions_environment_variable" "ci_docker_registry" {
+  count         = length(var.docker_registry) > 0 ? 1 : 0
+  environment   = github_repository_environment.repo_ci_environment.environment
+  repository    = var.repo
+  variable_name = "DOCKER_REGISTRY"
+  value         = var.docker_registry
+}
+resource "github_actions_environment_variable" "cd_docker_registry" {
+  count         = length(var.docker_registry) > 0 ? 1 : 0
+  environment   = github_repository_environment.repo_cd_environment.environment
+  repository    = var.repo
+  variable_name = "DOCKER_REGISTRY"
+  value         = var.docker_registry
+}
+
 # Store the stack's domain project id
 resource "github_actions_environment_secret" "ci_base64_domain_project_id" {
   repository      = var.repo

--- a/environment_secrets.tf
+++ b/environment_secrets.tf
@@ -78,14 +78,14 @@ resource "github_actions_environment_secret" "cd_gcp_service_account" {
 
 # Set parameters needed for k8s/helm
 resource "github_actions_environment_secret" "ci_k8s_namespace" {
-  count           = length(var.k8s_namespace) > 0 ? 1 : 0
+  count           = var.k8s_namespace == null || length(var.k8s_namespace) > 0 ? 1 : 0
   repository      = var.repo
   environment     = github_repository_environment.repo_ci_environment.environment
   secret_name     = "BASE64_K8S_NAMESPACE"          #tfsec:ignore:general-secrets-no-plaintext-exposure this isn't sensitive
   plaintext_value = base64encode(var.k8s_namespace) #tfsec:ignore:no-plaintext-exposure this isn't sensitive
 }
 resource "github_actions_environment_secret" "cd_k8s_namespace" {
-  count           = length(var.k8s_namespace) > 0 ? 1 : 0
+  count           = var.k8s_namespace == null || length(var.k8s_namespace) > 0 ? 1 : 0
   repository      = var.repo
   environment     = github_repository_environment.repo_cd_environment.environment
   secret_name     = "BASE64_K8S_NAMESPACE"          #tfsec:ignore:general-secrets-no-plaintext-exposure this isn't sensitive

--- a/environment_secrets.tf
+++ b/environment_secrets.tf
@@ -78,14 +78,14 @@ resource "github_actions_environment_secret" "cd_gcp_service_account" {
 
 # Set parameters needed for k8s/helm
 resource "github_actions_environment_secret" "ci_k8s_namespace" {
-  count           = var.k8s_namespace == null || length(var.k8s_namespace) > 0 ? 1 : 0
+  count           = var.k8s_namespace != null ? (length(var.k8s_namespace) > 0 ? 1 : 0) : 0
   repository      = var.repo
   environment     = github_repository_environment.repo_ci_environment.environment
   secret_name     = "BASE64_K8S_NAMESPACE"          #tfsec:ignore:general-secrets-no-plaintext-exposure this isn't sensitive
   plaintext_value = base64encode(var.k8s_namespace) #tfsec:ignore:no-plaintext-exposure this isn't sensitive
 }
 resource "github_actions_environment_secret" "cd_k8s_namespace" {
-  count           = var.k8s_namespace == null || length(var.k8s_namespace) > 0 ? 1 : 0
+  count           = var.k8s_namespace != null ? (length(var.k8s_namespace) > 0 ? 1 : 0) : 0
   repository      = var.repo
   environment     = github_repository_environment.repo_cd_environment.environment
   secret_name     = "BASE64_K8S_NAMESPACE"          #tfsec:ignore:general-secrets-no-plaintext-exposure this isn't sensitive

--- a/environment_secrets.tf
+++ b/environment_secrets.tf
@@ -19,21 +19,6 @@ resource "github_actions_environment_secret" "cd_base64_docker_registry" {
   plaintext_value = base64encode(var.docker_registry) #tfsec:ignore:no-plaintext-exposure this isn't sensitive
 }
 
-resource "github_actions_environment_variable" "ci_docker_registry" {
-  count         = length(var.docker_registry) > 0 ? 1 : 0
-  environment   = github_repository_environment.repo_ci_environment.environment
-  repository    = var.repo
-  variable_name = "DOCKER_REGISTRY"
-  value         = var.docker_registry
-}
-resource "github_actions_environment_variable" "cd_docker_registry" {
-  count         = length(var.docker_registry) > 0 ? 1 : 0
-  environment   = github_repository_environment.repo_cd_environment.environment
-  repository    = var.repo
-  variable_name = "DOCKER_REGISTRY"
-  value         = var.docker_registry
-}
-
 # Store the stack's domain project id
 resource "github_actions_environment_secret" "ci_base64_domain_project_id" {
   repository      = var.repo

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "github_repository_environment" "repo_cd_environment" {
   dynamic "reviewers" {
     for_each = var.skip_cd_approval == true ? [] : var.owners
     content {
-      teams = each.value
+      teams = reviewers.value
       users = []
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "github_repository_environment" "repo_cd_environment" {
   dynamic "reviewers" {
     for_each = var.skip_cd_approval == true ? [] : var.owners
     content {
-      teams = reviewers.value
+      teams = tonumber(reviewers.value)
       users = []
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,9 @@ resource "github_repository_environment" "repo_cd_environment" {
   repository  = var.repo
   environment = "${var.env_id}-cd"
   dynamic "reviewers" {
-    for_each = var.skip_cd_approval == true ? [] : [1]
+    for_each = var.skip_cd_approval == true ? [] : var.owners
     content {
-      teams = var.owners
+      teams = each.value
       users = []
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,9 @@ resource "github_repository_environment" "repo_cd_environment" {
   repository  = var.repo
   environment = "${var.env_id}-cd"
   dynamic "reviewers" {
-    for_each = var.skip_cd_approval == true ? [] : var.owners
+    for_each = var.skip_cd_approval == true ? [] : [1]
     content {
-      teams = tonumber(reviewers.value)
+      teams = var.owners
       users = []
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,6 @@
 # terraform service accounts, which can be assumed by the repo's github actions
 # workflows using workload identity
 
-data "github_team" "owner" {
-  slug = var.owner
-}
-
 # Create repo environments for the secrets and workload identity linking
 resource "github_repository_environment" "repo_ci_environment" {
   repository  = var.repo
@@ -25,7 +21,7 @@ resource "github_repository_environment" "repo_cd_environment" {
   dynamic "reviewers" {
     for_each = var.skip_cd_approval == true ? [] : [1]
     content {
-      teams = [data.github_team.owner.id]
+      teams = var.owners
       users = []
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "registry_readers_google_group_id" {
 
 variable "owners" {
   description = "GitHub team ids required to review the job for application updates. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access. Obtain id with `gh api https://api.github.com/orgs/<org>/teams/<slug> | jq '.id'`"
-  type        = list(string)
+  type        = list(number)
 }
 
 variable "skip_cd_approval" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,9 +42,9 @@ variable "registry_readers_google_group_id" {
   default     = ""
 }
 
-variable "owner" {
-  description = "GitHub teams required to review the job for application updates. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access. Example: eng"
-  type        = string
+variable "owners" {
+  description = "GitHub team ids required to review the job for application updates. This team must have some access to this repo at https://github.com/<owner>/<repo>/settings/access. Obtain id with `gh api https://api.github.com/orgs/<org>/teams/<slug> | jq '.id'`"
+  type        = list(string)
 }
 
 variable "skip_cd_approval" {


### PR DESCRIPTION
avoid looking up team ids for each stack every time by passing the team ids in directly
part of https://github.com/vivantehealth/gcp-env-terraform/issues/218

this will be a breaking change, replacing the `owner` string input with the `owner` list of numbers