### PR TITLE
Group memberships

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,7 @@ resource "google_cloud_identity_group_membership" "custom_group_membership" {
   preferred_member_key {
     id = google_service_account.gha_iac.email
   }
+  // For the initial use case, only MEMBER is needed, but in the future, if the IaC SA needs to add a runtime SA to a group, MANAGER would be needed. This could be either hard-coded or configurable (would require updates to the structure of the group_memberships variable and associated stack yaml schema in gcp-env-terraform)
   roles {
     name = "MEMBER"
   }

--- a/main.tf
+++ b/main.tf
@@ -127,3 +127,15 @@ resource "google_artifact_registry_repository_iam_member" "iac_admin" {
   role       = "roles/artifactregistry.repoAdmin"
   member     = "serviceAccount:${google_service_account.gha_iac.email}"
 }
+
+// Add the iac SA to any custom groups specified
+resource "google_cloud_identity_group_membership" "custom_group_membership" {
+  for_each = toset(var.group_memberships)
+  group    = each.value
+  preferred_member_key {
+    id = google_service_account.gha_iac.email
+  }
+  roles {
+    name = "MEMBER"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "k8s_namespace" {
   description = "Kubernetes namespace"
   default     = ""
 }
+
+variable "group_memberships" {
+  description = "List of group memberships to add the IaC service account to"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Adds group_memberships key to stack definition, allowing custom groups to be specified for the stack's IaC service account