### PR TITLE
fix mismatching branch policy values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "github_repository_environment" "repo_ci_environment" {
   # There appears to be no way to set the branch pattern through the API. See https://github.com/integrations/terraform-provider-github/issues/922#issuecomment-998957627
   deployment_branch_policy {
     protected_branches     = false
-    custom_branch_policies = var.restrict_environment_branches
+    custom_branch_policies = true
   }
 }
 resource "github_repository_environment" "repo_cd_environment" {


### PR DESCRIPTION
fixes the following error: `422 "custom_branch_policies" and "protected_branches" cannot have the same value []`

the last major release of this module took care of this for the cd env, but not the ci env
https://github.com/vivantehealth/terraform-gcp-stack/pull/32/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL29-R32