### PR TITLE
Support additional environment deployment approvers

### DIFF
--- a/.github/workflows/publish-terraform-module.yml
+++ b/.github/workflows/publish-terraform-module.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: GitHub semver release
         uses: vivantehealth/github-semver-release-action@v0
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Terraform cli
         uses: hashicorp/setup-terraform@v3
       - name: Terraform fmt

--- a/main.tf
+++ b/main.tf
@@ -15,13 +15,18 @@ resource "github_repository_environment" "repo_ci_environment" {
     custom_branch_policies = true
   }
 }
+
+locals {
+  deployment_approvers = concat(var.owners, var.additional_approvers)
+}
+
 resource "github_repository_environment" "repo_cd_environment" {
   repository  = var.repo
   environment = "${var.env_id}-cd"
   dynamic "reviewers" {
     for_each = var.skip_cd_approval == true ? [] : [1]
     content {
-      teams = var.owners
+      teams = local.deployment_approvers
       users = []
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,6 @@ variable "group_memberships" {
 
 variable "additional_approvers" {
   description = "List of additional approvers of environment deployments"
-  type        = list(string)
+  type        = list(number)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,9 @@ variable "group_memberships" {
   type        = list(string)
   default     = []
 }
+
+variable "additional_approvers" {
+  description = "List of additional approvers of environment deployments"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Add support for an extra list of github team IDs that can approve `-cd` deployments.